### PR TITLE
feat: extends series resolver

### DIFF
--- a/justfile
+++ b/justfile
@@ -62,6 +62,9 @@ kill TAG:
 tail TAG:
 	npx sqd squid:tail rubick@{{TAG}} -f
 
+brutal TAG:
+	npx sqd squid:update rubick@{{TAG}} --hardReset
+
 update-deps:
 	npx npm-check-updates -u
 

--- a/src/server-extension/model/event.model.ts
+++ b/src/server-extension/model/event.model.ts
@@ -18,6 +18,9 @@ export class EventEntity {
 
 @ObjectType()
 export class HistoryEntity {
+  @Field(() => String)
+  id!: string
+
   @Field(() => Date)
   date!: Date
 

--- a/src/server-extension/query/event.ts
+++ b/src/server-extension/query/event.ts
@@ -5,13 +5,13 @@ export const buyEvent = `SELECT
     LEFT JOIN nft_entity ne on ne.id = e.nft_id
     WHERE e.interaction = 'BUY' AND ne.collection_id = $1;`
 
-export const collectionEventHistory = `SELECT
-	ce.id as collection_id,
+export const collectionEventHistory = (idList: string) => `SELECT
+	ce.id as id,
 	DATE(e.timestamp),
 	count(e)
 FROM nft_entity ne
 JOIN collection_entity ce on ce.id = ne.collection_id
 JOIN event e on e.nft_id = ne.id
-WHERE e.interaction = 'BUY' and ce.id = $1 and e.timestamp >= NOW() - INTERVAL '30 DAY'
+WHERE e.interaction = 'BUY' and ce.id in (${idList}) and e.timestamp >= NOW() - INTERVAL '365 DAY'
 GROUP BY ce.id, DATE(e.timestamp)
 ORDER BY DATE(e.timestamp)`

--- a/src/server-extension/query/event.ts
+++ b/src/server-extension/query/event.ts
@@ -5,13 +5,15 @@ export const buyEvent = `SELECT
     LEFT JOIN nft_entity ne on ne.id = e.nft_id
     WHERE e.interaction = 'BUY' AND ne.collection_id = $1;`
 
-export const collectionEventHistory = (idList: string) => `SELECT
+export const collectionEventHistory = (idList: string, dateRange: string) => `SELECT
 	ce.id as id,
 	DATE(e.timestamp),
 	count(e)
 FROM nft_entity ne
 JOIN collection_entity ce on ce.id = ne.collection_id
 JOIN event e on e.nft_id = ne.id
-WHERE e.interaction = 'BUY' and ce.id in (${idList}) and e.timestamp >= NOW() - INTERVAL '365 DAY'
+WHERE e.interaction = 'BUY'
+and ce.id in (${idList})
+${dateRange}
 GROUP BY ce.id, DATE(e.timestamp)
 ORDER BY DATE(e.timestamp)`

--- a/src/server-extension/query/spotlight.ts
+++ b/src/server-extension/query/spotlight.ts
@@ -8,7 +8,7 @@ FROM
 WHERE
   e.interaction = 'BUY'
   and ne.issuer != ne.current_owner
-  and ne.issuer = $ 1
+  and ne.issuer = $1
   and e.timestamp >= NOW() - INTERVAL '30 DAY'
 GROUP BY
   ne.issuer,

--- a/src/server-extension/resolvers/series.ts
+++ b/src/server-extension/resolvers/series.ts
@@ -32,6 +32,7 @@ enum DateRange {
   ALL_DAY = 'ALL DAY'
 }
 
+type CollectionIDs = string[]
 @Resolver(of => SeriesEntity)
 export class SeriesResolver {
   constructor(private tx: () => Promise<EntityManager>) { }
@@ -76,11 +77,16 @@ export class SeriesResolver {
   }
 
   @Query(() => [HistoryEntity])
-  async seriesInsightBuyHistory(ids: string[]) {
+  async seriesInsightBuyHistory(
+    @Arg('ids', () => [String!], { nullable: false }) ids: CollectionIDs
+    // @Arg('dateRange', { nullable: false, defaultValue: '7 DAY' }) dateRange: DateRange,
+  ) {
+    const idList = JSON.stringify(ids).replace(/\"/g, '\'').replace(/[\[|\]]/g, '')
     const manager = await this.tx()
     const result = await manager
       .getRepository(NFTEntity)
-      .query(collectionEventHistory, [ids])
+      .query(collectionEventHistory(idList))
+    return result
   }
 
   // @FieldResolver(() => [HistoryEntity])

--- a/src/server-extension/resolvers/series.ts
+++ b/src/server-extension/resolvers/series.ts
@@ -4,6 +4,7 @@ import { NFTEntity, Interaction } from '../../model/generated'
 import { SeriesEntity } from '../model/series.model'
 import { HistoryEntity } from "../model/event.model";
 import { collectionEventHistory } from "../query/event";
+import { makeQuery, toSqlInParams } from "../utils";
 
 enum OrderBy {
   volume = 'volume',
@@ -68,10 +69,7 @@ export class SeriesResolver {
       GROUP BY ce.id, me.image, ce.name 
       ORDER BY ${orderBy} ${orderDirection}
       LIMIT ${limit} OFFSET ${offset}`
-    const manager = await this.tx()
-    const result: SeriesEntity[] = await manager
-      .getRepository(NFTEntity)
-      .query(query)
+    const result: SeriesEntity[] = await makeQuery(this.tx, NFTEntity, query)
 
     return result
   }
@@ -81,7 +79,7 @@ export class SeriesResolver {
     @Arg('ids', () => [String!], { nullable: false }) ids: CollectionIDs,
     @Arg('dateRange', { nullable: false, defaultValue: '7 DAY' }) dateRange: DateRange,
   ) {
-    const idList = JSON.stringify(ids).replace(/\"/g, '\'').replace(/[\[|\]]/g, '')
+    const idList = toSqlInParams(ids)
     const computedDateRange = dateRange === 'ALL DAY'
       ? ''
       : `AND e.timestamp >= NOW() - INTERVAL '${dateRange}'`

--- a/src/server-extension/resolvers/series.ts
+++ b/src/server-extension/resolvers/series.ts
@@ -78,23 +78,18 @@ export class SeriesResolver {
 
   @Query(() => [HistoryEntity])
   async seriesInsightBuyHistory(
-    @Arg('ids', () => [String!], { nullable: false }) ids: CollectionIDs
-    // @Arg('dateRange', { nullable: false, defaultValue: '7 DAY' }) dateRange: DateRange,
+    @Arg('ids', () => [String!], { nullable: false }) ids: CollectionIDs,
+    @Arg('dateRange', { nullable: false, defaultValue: '7 DAY' }) dateRange: DateRange,
   ) {
     const idList = JSON.stringify(ids).replace(/\"/g, '\'').replace(/[\[|\]]/g, '')
+    const computedDateRange = dateRange === 'ALL DAY'
+      ? ''
+      : `AND e.timestamp >= NOW() - INTERVAL '${dateRange}'`
     const manager = await this.tx()
     const result = await manager
       .getRepository(NFTEntity)
-      .query(collectionEventHistory(idList))
+      .query(collectionEventHistory(idList, computedDateRange))
     return result
   }
 
-  // @FieldResolver(() => [HistoryEntity])
-  // async buyHistory(@Root() series: SeriesEntity) {
-
-  //   const manager = await this.tx()
-  //   return await manager
-  //     .getRepository(NFTEntity)
-  //     .query(collectionEventHistory, [series.id])
-  // }
 }

--- a/src/server-extension/resolvers/series.ts
+++ b/src/server-extension/resolvers/series.ts
@@ -22,7 +22,15 @@ enum OrderDirection {
   ASC = 'ASC',
 }
 
-type DateRange = '24 HOUR' | '7 DAY' | '14 DAY' | '30 DAY' | '90 DAY' | '180 DAY' | 'ALL DAY'
+enum DataRange {
+  DAY = '24 HOUR',
+  WEEK = '7 DAY',
+  TWO_WEEK = '14 DAY',
+  MONTH = '30 DAY',
+  QUARTER = '90 DAY',
+  HALF_YEAR = '180 DAY',
+  ALL_DAY = 'ALL DAY'
+}
 
 @Resolver(of => SeriesEntity)
 export class SeriesResolver {

--- a/src/server-extension/utils.ts
+++ b/src/server-extension/utils.ts
@@ -10,3 +10,12 @@ export async function makeQuery<E, V>(txManager: () => Promise<EntityManager>, e
 export async function genericRepositoryQuery<T, V>(repository: Repository<T>, query: string, args?: any[]): Promise<V> {
   return repository.query(query, args) as Promise<V>
 }
+
+/**
+ * @description hack sql IN parameters
+ *              https://github.com/kodadot/rubick/pull/72#discussion_r873325836
+ * @returns ["id1", "id2"] -> "'id1','id2'"
+ */
+export function toSqlInParams(list: string[]): string {
+  return JSON.stringify(list).replace(/\"/g, '\'').replace(/[\[|\]]/g, '')
+}


### PR DESCRIPTION
This PR is mainly supporting two things
1. New Resolver would return buy history
2. Extend the current series-insight resolver, which now can filter by provided date range