### PR TITLE
:zap: limit the chache queries to some optimal numbers

### DIFF
--- a/src/mappings/utils/cache.ts
+++ b/src/mappings/utils/cache.ts
@@ -11,37 +11,46 @@ const STATUS_ID: string = "0"
 enum Query {
 
     series = `SELECT
-            ce.id, ce.name, ce.meta_id as metadata, me.image, ce.issuer,
-            COUNT(distinct ne.meta_id) as unique,
-            COUNT(distinct ne.current_owner) as unique_collectors,
-            COUNT(distinct ne.current_owner) as sold,
-            COUNT(ne.*) as total,
-            AVG(ne.price) as average_price,
-            MIN(NULLIF(ne.price, 0)) as floor_price,
-            COALESCE(MAX(e.meta :: bigint), 0) as highest_sale,
-            COALESCE(SUM(e.meta::bigint), 0) as volume,
-            COUNT(e.*) as buys,
-            COUNT(em.*) as emote_count
-        FROM collection_entity ce
+        ce.id,
+        ce.name,
+        ce.meta_id                         as metadata,
+        me.image,
+        ce.issuer,
+        COUNT(distinct ne.meta_id)         as unique,
+        COUNT(distinct ne.current_owner)   as unique_collectors,
+        COUNT(distinct ne.current_owner)   as sold,
+        COUNT(ne.*)                        as total,
+        AVG(ne.price)                      as average_price,
+        MIN(NULLIF(ne.price, 0))           as floor_price,
+        COALESCE(MAX(e.meta :: bigint), 0) as highest_sale,
+        COALESCE(SUM(e.meta::bigint), 0)   as volume,
+        COUNT(e.*)                         as buys,
+        COUNT(em.*)                        as emote_count
+    FROM collection_entity ce
         LEFT JOIN metadata_entity me on ce.meta_id = me.id
         LEFT JOIN nft_entity ne on ce.id = ne.collection_id
         LEFT JOIN emote em on ne.id = em.nft_id
         JOIN event e on ne.id = e.nft_id
-        WHERE e.interaction = 'BUY'
-        GROUP BY ce.id, me.image, ce.name`,
+    WHERE e.interaction = 'BUY'
+    GROUP BY ce.id, me.image, ce.name
+    ORDER BY volume DESC
+    LIMIT 900`,
 
     spotlight = `SELECT
-        issuer as id,
-        COUNT(distinct collection_id) as collections,
-        COUNT(distinct meta_id) as unique,
-        AVG(price) as average,
-        COUNT(*) as total,
-        COUNT(distinct ne.current_owner) as unique_collectors,
+        issuer                                                         as id,
+        COUNT(distinct collection_id)                                  as collections,
+        COUNT(distinct meta_id)                                        as unique,
+        AVG(price)                                                     as average,
+        COUNT(*)                                                       as total,
+        COUNT(distinct ne.current_owner)                               as unique_collectors,
         SUM(CASE WHEN ne.issuer <> ne.current_owner THEN 1 ELSE 0 END) as sold,
-        COALESCE(SUM(e.meta::bigint), 0) as volume
+        COALESCE(SUM(e.meta::bigint), 0)                               as volume
     FROM nft_entity ne
-    JOIN event e on e.nft_id = ne.id WHERE e.interaction = 'BUY'
-    GROUP BY issuer`,
+        JOIN event e on e.nft_id = ne.id
+    WHERE e.interaction = 'BUY'
+    GROUP BY issuer
+    ORDER BY sold DESC
+    LIMIT 360`,
 
     collector_whale = `SELECT
         ne.current_owner                 as id,

--- a/src/mappings/utils/cache.ts
+++ b/src/mappings/utils/cache.ts
@@ -50,7 +50,7 @@ enum Query {
     WHERE e.interaction = 'BUY'
     GROUP BY issuer
     ORDER BY sold DESC
-    LIMIT 360`,
+    LIMIT 400`,
 
     collector_whale = `SELECT
         ne.current_owner                 as id,


### PR DESCRIPTION
Setting limits to the cache queries:
Spotlight 400
Series 900

How did I get those numbers?

1. let's make some base counts

```sql
select count(*) from series; // 1572
select count(*) from spotlight; // 720
```

2. let's set some base metrics? 

for series I care about collection who has at least 1 KSM in the volume

```sql
select count(*) from series where volume <= 1000000000000; // 794
```
for spotlight want to see artists that have sell something

```sql
select count(*) from spotlight group by sold > 1 // 180, 540 // 180 sold 0 or 1 item
```



to be safe with the numbers:
794 -> moved to 900 - in case we have more collections
540 -> if user is not in the first half than ngmi

