### PR TITLE
fix: add missing animation_url to lastEvent resolver

### DIFF
--- a/src/server-extension/model/event.model.ts
+++ b/src/server-extension/model/event.model.ts
@@ -54,6 +54,9 @@ export class LastEventEntity {
   @Field(() => String, { nullable: true })
   image!: String
 
+  @Field(() => String, {nullable: true, name: 'animationUrl'})
+  animation_url!: string | undefined | null
+
   constructor(props: Partial<LastEventEntity>) {
     Object.assign(this, props);
   }

--- a/src/server-extension/query/event.ts
+++ b/src/server-extension/query/event.ts
@@ -26,6 +26,7 @@ export const lastEventQuery = (whereCondition: string) => `SELECT
     ne.metadata as metadata,
     e.current_owner,
     me.image as image,
+    me.animation_url,
     MAX(e.timestamp) as timestamp,
     MAX(e.meta::bigint) as value
 


### PR DESCRIPTION
**Thank you for your contribution** to the [KodaDot Indexer](https://kodadot.xyz).
👇 \_ Let's make a quick check before the contribution.

### PR type

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring

### What's new?

- [ ] PR closes #<issue_number>
- [x] This PR is required for kodadot/nft-gallery#3767

### Before submitting Pull Request, please make sure:

- [x] My contribution builds **clean without any errors or warnings**
- [x] I've merged recent default branch -- **main** and I've no conflicts
- [x] I've tried to respect high code quality standards
- [x] I've didn't break any original functionality
- [x] I've posted a screenshot of demonstrated change in this PR

### Optional

- [ ] I've run the indexer and it hasn't failed
- [ ] I've changed schema and performed a migration
- [ ] I found edge cases

### Screenshot

- [x] My contribution is a **resolver** so I have pic from playground

<img width="1295" alt="image" src="https://user-images.githubusercontent.com/31397967/185193430-23d2234b-002b-4d37-aa2c-2cfae30e20a7.png">

